### PR TITLE
Complete functionality to have both users' screens show up, edit queries for interviewer/interviewee sessions

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -20,7 +20,7 @@ export default class App extends React.Component {
       <Router history={browserHistory}>
         <Route path="/" component={MainLayout}>
           <IndexRoute component={HomeView} />
-          <Route path="record" component={RecordView} />
+          <Route path="record(/:sessionId)" component={RecordView} />
           <Route path="sessions/interviewer" component={InterviewerSessionsView} />
           <Route path="sessions/interviewee" component={IntervieweeSessionsView} />
           <Route path="reports/:sessionId" component={ReportView} />

--- a/client/style/record-view.css
+++ b/client/style/record-view.css
@@ -17,10 +17,9 @@ video#webcam {
 }
 
 #current-snapshot {
-  right: 0;
-  position: absolute;
-  width: 20%;
-  height: 20%;
+  width: 0%;
+  height: 0%;
+  opacity: 0;
 }
 
 .record-box, .record-form {

--- a/server/controllers/SessionController.js
+++ b/server/controllers/SessionController.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   getInterviewerSessions: function(req, res) {
-    Session.where({ interviewerId: req.user.id }).fetchAll()
+    Session.where({ interviewerId: req.user.id }).where('duration', '<>', 'Temporary Duration').fetchAll()
       .then(function(sessions) {
         res.status(200).send(sessions);
       })
@@ -36,7 +36,7 @@ module.exports = {
   },
 
   getIntervieweeSessions: function(req, res) {
-    Session.where({ intervieweeId: req.user.id }).fetchAll()
+    Session.where({ intervieweeId: req.user.id }).where('duration', '<>', 'Temporary Duration').fetchAll()
       .then(function(sessions) {
         res.status(200).send(sessions);
       })


### PR DESCRIPTION
### Summary

<!--- Provide a general summary of your changes in the Title above -->
- Completed functionality to have both users' screens show up
- Edited queries for interviewer/interviewee sessions pages to exclude invalid sessions
##### Description

<!--- Describe your changes in detail -->
- Completed functionality to have both users' screens show up
  - Added div to have other user's video show up
  - Linked the other user's stream to show up on the page as well
- Edited queries for interviewer/interviewee sessions pages to exclude invalid sessions
  - 'Temporary Duration' sessions now excluded
##### Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
##### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Before, we couldn't see the other user's video, which was the whole point of having the video conferencing
##### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated Testing
- [ ] Documentation
##### Testing Details

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

<!--- If there are none to be shared, report 'Travis CI - Build Passing'  -->
- Chat with another person and you'll see their screen too
##### Screenshots (if appropriate)

<!--- Report 'N/A' if none --->
- N/A
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
